### PR TITLE
Killmail template fixes

### DIFF
--- a/ThunderED/Classes/Entities/KillDataEntry.cs
+++ b/ThunderED/Classes/Entities/KillDataEntry.cs
@@ -102,8 +102,8 @@ namespace ThunderED.Classes.Entities
                         {"{attackerAllyOrCorpTicker}", rAttackerAlliance?.ticker ?? rAttackerCorp?.ticker},                        
                         {"{attackersCount}", attackers?.Length.ToString()},
                         {"{kmId}", killmailID.ToString()},
-                        {"{isNpcKill}", isNPCKill.ToString()},
                         {"{timestamp}", killTime},
+                        {"{isNpcKill}", isNPCKill.ToString() ?? "false"},
                         {"{isSoloKill}", kill?.zkb?.solo.ToString() ?? "false"},
                         {"{isAwoxKill}", kill?.zkb?.awox.ToString() ?? "false"},
                     };
@@ -187,9 +187,9 @@ namespace ThunderED.Classes.Entities
                         {"{attackerAllyOrCorpTicker}", rAttackerAlliance?.ticker ?? rAttackerCorp?.ticker},                        
                         {"{attackersCount}", attackers.Length.ToString()},
                         {"{kmId}", killmailID.ToString()},
-                        {"{isNpcKill}", isNPCKill.ToString()},
                         {"{timestamp}", killTime},
                         {"{isLoss}", "false"},
+                        {"{isNpcKill}", isNPCKill.ToString() ?? "false"},
                         {"{isSoloKill}", kill?.zkb?.solo.ToString() ?? "false"},
                         {"{isAwoxKill}", kill?.zkb?.awox.ToString() ?? "false"},
                     };

--- a/ThunderED/Classes/TemplateHelper.cs
+++ b/ThunderED/Classes/TemplateHelper.cs
@@ -60,11 +60,17 @@ namespace ThunderED.Classes
             {
                 var isNpcKill = dic.ContainsKey("{isNpcKill}") && Convert.ToBoolean(dic["{isNpcKill}"]);
                 var isLoss = dic.ContainsKey("{isLoss}") && Convert.ToBoolean(dic["{isLoss}"]);
+                var isAwox = dic.ContainsKey( "{isAwoxKill}" ) && Convert.ToBoolean( dic["{isAwoxKill}"] );
+                var isSolo = dic.ContainsKey( "{isSoloKill}" ) && Convert.ToBoolean( dic["{isSoloKill}"] );
                 if (dic.ContainsKey("{isNpcKill}"))
                     dic.Remove("{isNpcKill}");
                 if (dic.ContainsKey("{isLoss}"))
                     dic.Remove("{isLoss}");
-                             
+                if (dic.ContainsKey( "{isAwoxKill}" ))
+                    dic.Remove( "{isAwoxKill}" );
+                if (dic.ContainsKey( "{isSoloKill}" ))
+                    dic.Remove( "{isSoloKill}" );
+
                 var isRadiusRange = dic.ContainsKey("{isRangeMode}") && Convert.ToBoolean(dic["{isRangeMode}"]);
                 if (dic.ContainsKey("{isRangeMode}"))
                     dic.Remove("{isRangeMode}");
@@ -158,7 +164,25 @@ namespace ThunderED.Classes
                                 if (isLoss) return;
                                 text = text.Substring(13, text.Length - 13).Trim();
                             }
-
+                            
+                            if (text.StartsWith("#if {isAwoxKill}", StringComparison.OrdinalIgnoreCase)) {
+                                if (!isAwox) return;
+                                text = text.Substring(16, text.Length - 16).Trim();
+                            }
+                            if (text.StartsWith( "#if !{isAwoxKill}", StringComparison.OrdinalIgnoreCase )) {
+                                if (isAwox) return;
+                                text = text.Substring(17, text.Length - 17).Trim();
+                            }
+                            
+                            if (text.StartsWith( "#if {isSoloKill}", StringComparison.OrdinalIgnoreCase )) {
+                                if (!isSolo) return;
+                                text = text.Substring(16, text.Length - 16).Trim();
+                            }
+                            if (text.StartsWith( "#if !{isSoloKill}", StringComparison.OrdinalIgnoreCase )) {
+                                if (isSolo) return;
+                                text = text.Substring(17, text.Length - 17).Trim();
+                            }
+                            
                             if (!isAuthor && text.StartsWith(".WithAuthor", StringComparison.OrdinalIgnoreCase))
                             {
                                 isAuthor = true;
@@ -184,7 +208,6 @@ namespace ThunderED.Classes
                             }
                             else
                             {
-
                                 if (text.StartsWith(".WithColor", StringComparison.OrdinalIgnoreCase))
                                     embed.WithColor(GetColor(text));
                                 else if (text.StartsWith(".WithDescription(", StringComparison.OrdinalIgnoreCase))
@@ -209,8 +232,8 @@ namespace ThunderED.Classes
                                     embed.WithFooter(GetText(text));
                                 else if (text.StartsWith(".WithTimestamp", StringComparison.OrdinalIgnoreCase))
                                 {
-                                    if (DateTimeOffset.TryParse(dic["timestamp"], out var time))
-                                        embed.WithTimestamp(time);
+                                    if (DateTimeOffset.TryParse(dic["{timestamp}"], out var time))
+                                         embed.WithTimestamp(time);
                                     else embed.WithCurrentTimestamp();
                                 }
                             }

--- a/ThunderED/Modules/OnDemand/LiveKillFeedModule.cs
+++ b/ThunderED/Modules/OnDemand/LiveKillFeedModule.cs
@@ -70,7 +70,7 @@ namespace ThunderED.Modules.OnDemand
                             await APIHelper.DiscordAPI.SendMessageAsync(bigKillGlobalChan, kill.zkb.url);
                         else
                         {                            
-                            if (await km.Refresh(Reason, kill) && !await TemplateHelper.PostTemplatedMessage(MessageTemplateType.KillMailBig, km.dic, bigKillGlobalChan, discordGroupName))
+                            if (await km.Refresh(Reason, kill) && !await TemplateHelper.PostTemplatedMessage(MessageTemplateType.KillMailBig, km.dic, bigKillGlobalChan, groupPair.Value.ShowGroupName ? discordGroupName : " "))
                             {
                                 await APIHelper.DiscordAPI.SendEmbedKillMessage(bigKillGlobalChan, new Color(0xFA2FF4), km, null);
                             }
@@ -85,7 +85,7 @@ namespace ThunderED.Modules.OnDemand
                         {
                             if (isUrlOnly)
                                 await APIHelper.DiscordAPI.SendMessageAsync(c, kill.zkb.url);
-                            else if (await km.Refresh(Reason, kill) && !await TemplateHelper.PostTemplatedMessage(MessageTemplateType.KillMailGeneral, km.dic, c, discordGroupName))
+                            else if (await km.Refresh(Reason, kill) && !await TemplateHelper.PostTemplatedMessage(MessageTemplateType.KillMailGeneral, km.dic, c, groupPair.Value.ShowGroupName ? discordGroupName : " "))
                             {
                                 await APIHelper.DiscordAPI.SendEmbedKillMessage(c, new Color(0x00FF00), km, null);
                             }
@@ -114,12 +114,14 @@ namespace ThunderED.Modules.OnDemand
                                     km.dic["{isLoss}"] = "true";
                                     try
                                     {
-                                        if (!await TemplateHelper.PostTemplatedMessage(MessageTemplateType.KillMailBig, km.dic, bigKillChannel, discordGroupName))
+                                        if (!await TemplateHelper.PostTemplatedMessage(MessageTemplateType.KillMailBig, km.dic, bigKillChannel, 
+                                            groupPair.Value.ShowGroupName ? discordGroupName : " "))
                                         {
                                             await APIHelper.DiscordAPI.SendEmbedKillMessage(bigKillChannel, new Color(0xD00000), km, null,
                                                 groupPair.Value.ShowGroupName ? discordGroupName : " ");
                                             if (sendBigToGeneral && c != bigKillChannel)
-                                                if (!await TemplateHelper.PostTemplatedMessage(MessageTemplateType.KillMailBig, km.dic, c, discordGroupName))
+                                                if (!await TemplateHelper.PostTemplatedMessage(MessageTemplateType.KillMailBig, km.dic, c, 
+                                                    groupPair.Value.ShowGroupName ? discordGroupName : " "))
                                                     await APIHelper.DiscordAPI.SendEmbedKillMessage(c, new Color(0xD00000), km, null,
                                                         groupPair.Value.ShowGroupName ? discordGroupName : " ");
                                         }
@@ -147,7 +149,8 @@ namespace ThunderED.Modules.OnDemand
                                     km.dic["{isLoss}"] = "true";
                                     try
                                     {
-                                        if (!await TemplateHelper.PostTemplatedMessage(MessageTemplateType.KillMailGeneral, km.dic, c, discordGroupName))
+                                        if (!await TemplateHelper.PostTemplatedMessage(MessageTemplateType.KillMailGeneral, km.dic, c, 
+                                            groupPair.Value.ShowGroupName ? discordGroupName : " "))
                                         {
                                             await APIHelper.DiscordAPI.SendEmbedKillMessage(c, new Color(0xFF0000), km, null,
                                                 groupPair.Value.ShowGroupName ? discordGroupName : " ");
@@ -184,13 +187,15 @@ namespace ThunderED.Modules.OnDemand
                                         km.dic["{isLoss}"] = "false";
                                         try
                                         {
-                                            if (!await TemplateHelper.PostTemplatedMessage(MessageTemplateType.KillMailBig, km.dic, bigKillChannel, discordGroupName))
+                                            if (!await TemplateHelper.PostTemplatedMessage(MessageTemplateType.KillMailBig, km.dic, bigKillChannel, 
+                                                groupPair.Value.ShowGroupName ? discordGroupName : " "))
                                             {
                                                 await APIHelper.DiscordAPI.SendEmbedKillMessage(bigKillChannel, new Color(0x00D000), km, null,
                                                     groupPair.Value.ShowGroupName ? discordGroupName : " ");
                                                 if (sendBigToGeneral && c != bigKillChannel)
                                                 {
-                                                    if (!await TemplateHelper.PostTemplatedMessage(MessageTemplateType.KillMailBig, km.dic, c, discordGroupName))
+                                                    if (!await TemplateHelper.PostTemplatedMessage(MessageTemplateType.KillMailBig, km.dic, c, 
+                                                        groupPair.Value.ShowGroupName ? discordGroupName : " "))
                                                         await APIHelper.DiscordAPI.SendEmbedKillMessage(c, new Color(0x00D000), km, null,
                                                             groupPair.Value.ShowGroupName ? discordGroupName : " ");
                                                 }
@@ -217,7 +222,8 @@ namespace ThunderED.Modules.OnDemand
                                     km.dic["{isLoss}"] = "false";
                                     try
                                     {
-                                        if (!await TemplateHelper.PostTemplatedMessage(MessageTemplateType.KillMailGeneral, km.dic, c, discordGroupName))
+                                        if (!await TemplateHelper.PostTemplatedMessage(MessageTemplateType.KillMailGeneral, km.dic, c, 
+                                            groupPair.Value.ShowGroupName ? discordGroupName : " "))
                                         {
                                             await APIHelper.DiscordAPI.SendEmbedKillMessage(c, new Color(0x00FF00), km, null,
                                                 groupPair.Value.ShowGroupName ? discordGroupName : " ");


### PR DESCRIPTION
Fixed `.WithTimestamp` error.
Added missing code to make `{isAwoxKill}` and `{isSoloKill}` work.
Fixed bot sometimes posting killmails with groupname even when settings specified not to.